### PR TITLE
Hotfix/14-204-content-type-error

### DIFF
--- a/__tests__/middleware.test.js
+++ b/__tests__/middleware.test.js
@@ -106,6 +106,48 @@ describe('apiMiddleware', () => {
     expect(response).toEqual(expectedResponse);
   });
 
+  it('Should dispatch action success when API returns 204', async () => {
+    const get = () => {};
+
+    const apiCallFunction = jest.fn().mockResolvedValue({
+      headers: {
+        get,
+        status: 204,
+      },
+    });
+
+    const action = {
+      types: {
+        request: 'REQUEST',
+        success: 'SUCCESS',
+        failure: 'FAILURE',
+      },
+      apiCallFunction,
+    };
+
+    const response = await apiMiddleware({ dispatch, getState })(next)(action);
+
+    expect(next).not.toBeCalled();
+    expect(getState).toBeCalled();
+
+    const expectedResponse = {
+      headers: {
+        get,
+        status: 204,
+      },
+    };
+    expect(dispatch).toBeCalledWith({
+      extraData: {},
+      type: 'REQUEST',
+    });
+    expect(dispatch).toBeCalledWith({
+      extraData: {},
+      response: expectedResponse,
+      type: 'SUCCESS',
+    });
+    expect(response).toEqual(expectedResponse);
+  });
+
   it('Should dispatch action failure when has some error on request - no json', async () => {
     function get() {
       return 'application/x-www-form-urlencoded';
@@ -237,7 +279,7 @@ describe('apiMiddleware', () => {
     }
   });
 
-  it('Should pass action forwarn if no types are defined', async () => {
+  it('Should pass action forward if no types are defined', async () => {
     const action = {
       type: 'REQUEST',
     };

--- a/dist/middleware.js
+++ b/dist/middleware.js
@@ -62,7 +62,9 @@ function apiMiddleware(_ref) {
       return new Promise(function (resolve, reject) {
         apiCallFunction(dispatch).then(function (response) {
           // if it's a json response, we unpack and parse it
-          if (response.headers && typeof response.headers.get === 'function' && response.headers.get('content-type').startsWith('application/json')) {
+          var contentType = response.headers && typeof response.headers.get === 'function' && response.headers.get('content-type');
+
+          if (contentType && contentType.startsWith('application/json')) {
             response.json().then(function (data) {
               response.data = data; // from backend response
 
@@ -83,7 +85,9 @@ function apiMiddleware(_ref) {
           }
         }).catch(function (error) {
           // if it's a json response, we unpack and parse it
-          if (error.headers && typeof error.headers.get === 'function' && error.headers.get('content-type').startsWith('application/json')) {
+          var contentType = error.headers && typeof error.headers.get === 'function' && error.headers.get('content-type');
+
+          if (contentType && contentType.startsWith('application/json')) {
             error.json().then(function (data) {
               error.data = data; // form backend error
 

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -47,11 +47,12 @@ export default function apiMiddleware({ dispatch, getState }) {
       apiCallFunction(dispatch)
         .then(response => {
           // if it's a json response, we unpack and parse it
-          if (
+          const contentType =
             response.headers &&
             typeof response.headers.get === 'function' &&
-            response.headers.get('content-type').startsWith('application/json')
-          ) {
+            response.headers.get('content-type');
+
+          if (contentType && contentType.startsWith('application/json')) {
             response.json().then(data => {
               response.data = data; // from backend response
               dispatch({ extraData, response, type: types.success });
@@ -64,11 +65,12 @@ export default function apiMiddleware({ dispatch, getState }) {
         })
         .catch(error => {
           // if it's a json response, we unpack and parse it
-          if (
+          const contentType =
             error.headers &&
             typeof error.headers.get === 'function' &&
-            error.headers.get('content-type').startsWith('application/json')
-          ) {
+            error.headers.get('content-type');
+
+          if (contentType && contentType.startsWith('application/json')) {
             error.json().then(data => {
               error.data = data; // form backend error
               dispatch({ extraData, error, response: error, type: types.failure });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-redux-api-tools",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "Middleware and helpers to improve the React-Redux flow when communicating with APIs.",
   "main": "index.js",
   "scripts": {
@@ -62,7 +62,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "npm run lint && npm run test"
+      "pre-commit": "npm run lint && npm run dist && npm run test"
     }
   }
 }


### PR DESCRIPTION
fixes #14 
This PR fixess all issues related to content-type headers.
We also added a regression test to make sure 204 requests without content-type response headers stop breaking.